### PR TITLE
Replace 'function' and 'method' with 'command'

### DIFF
--- a/content/Day3.md
+++ b/content/Day3.md
@@ -7,16 +7,20 @@
 A simple app that performs conditionally prints out alternative messages depending on whether the button was pressed or not.
 
 Flow of the app:
+
 1. By default, the app prints `Goodbye`
 2. Upon clicking on the button, the app displays the alternative message `Why hello there`
 
 ## Demo app
-The deployed Streamlit app should look something like the one shown in the below link: 
+
+The deployed Streamlit app should look something like the one shown in the below link:
 
 [![Streamlit App](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://share.streamlit.io/dataprofessor/st.button/)
 
 ## Code
+
 Here's the code to implement the above mentioned app:
+
 ```python
 import streamlit as st
 
@@ -29,12 +33,15 @@ else:
 ```
 
 ## Line-by-line explanation
+
 The very first thing to do when creating a Streamlit app is to start by importing the `streamlit` library as `st` like so:
+
 ```python
 import streamlit as st
 ```
 
 This is followed by creating a header text for the app:
+
 ```python
 st.header('st.button')
 ```
@@ -47,13 +54,17 @@ if st.button('Say hello'):
 else:
      st.write('Goodbye')
 ```
-As we can see from the above code box, the `st.button()` function accepts the `label` input argument of `Say hello`, which is the text that the button displays.
 
-The `st.write` function is used to print text messages of either `Why hello there` or `Goodbye` depending on whether the button was clicked or not, which is implemented via:
+As we can see from the above code box, the `st.button()` command accepts the `label` input argument of `Say hello`, which is the text that the button displays.
+
+The `st.write` command is used to print text messages of either `Why hello there` or `Goodbye` depending on whether the button was clicked or not, which is implemented via:
+
 ```python
 st.write('Why hello there')
 ```
-and 
+
+and
+
 ```python
 st.write('Goodbye')
 ```
@@ -62,13 +73,14 @@ It is important to note that the above `st.write` statements are placed under th
 
 ## Next steps
 
-Now that you have created the Streamlit app locally, it's time to deploy it to [Streamlit Cloud](https://streamlit.io/cloud) as will be explained soon in an upcoming challenge. 
+Now that you have created the Streamlit app locally, it's time to deploy it to [Streamlit Cloud](https://streamlit.io/cloud) as will be explained soon in an upcoming challenge.
 
-Because this is the first week of your challenge, we provide the full code (as shown in the code box above) and solution (the demo app) right inside this webpage. 
+Because this is the first week of your challenge, we provide the full code (as shown in the code box above) and solution (the demo app) right inside this webpage.
 
 Moving forward in the next challenges, it is recommended that you first try implementing the Streamlit app yourself.
 
 Don't worry if you get stuck, you can always take a peek at the solution.
 
 ## References
+
 Read about [`st.button`](https://docs.streamlit.io/library/api-reference/widgets/st.button) in the Streamlit API Documentation.

--- a/content/Day5.md
+++ b/content/Day5.md
@@ -2,7 +2,8 @@
 
 `st.write` allows writing text and arguments to the Streamlit app.
 
-In addition to being able to display text, the following can also be displayed via the `st.write()` method:
+In addition to being able to display text, the following can also be displayed via the `st.write()` command:
+
 - Prints strings; works like `st.markdown()`
 - Displays a Python `dict`
 - Displays `pandas` DataFrame can be displayed as a table
@@ -11,15 +12,18 @@ In addition to being able to display text, the following can also be displayed v
 
 ## What we're building?
 
-A simple app showing the various ways on how to use the `st.write()` method for displaying text, numbers, DataFrames and plots.
+A simple app showing the various ways on how to use the `st.write()` command for displaying text, numbers, DataFrames and plots.
 
 ## Demo app
-The deployed Streamlit app should look something like the one shown in the below link: 
+
+The deployed Streamlit app should look something like the one shown in the below link:
 
 [![Streamlit App](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://share.streamlit.io/dataprofessor/st.write/)
 
 ## Code
+
 Here's how to use st.write:
+
 ```python
 import numpy as np
 import altair as alt
@@ -59,30 +63,36 @@ st.write(c)
 ```
 
 ## Line-by-line explanation
+
 The very first thing to do when creating a Streamlit app is to start by importing the `streamlit` library as `st` like so:
+
 ```python
 import streamlit as st
 ```
 
 This is followed by creating a header text for the app:
+
 ```python
 st.header('st.write')
 ```
 
 **Example 1**
 Its basic use case is to display text and Markdown-formatted text:
+
 ```python
 st.write('Hello, *World!* :sunglasses:')
 ```
 
 **Example 2**
 As mentioned above, it can also be used to display other data formats such as numbers:
+
 ```python
 st.write(1234)
 ```
 
 **Example 3**
 DataFrames can also be displayed as follows:
+
 ```python
 df = pd.DataFrame({
      'first column': [1, 2, 3, 4],
@@ -93,12 +103,14 @@ st.write(df)
 
 **Example 4**
 You can pass in multiple arguments:
+
 ```python
 st.write('Below is a DataFrame:', df, 'Above is a dataframe.')
 ```
 
 **Example 5**
 Finally, you can also display plots as well by passing it to a variable as follows:
+
 ```python
 df2 = pd.DataFrame(
      np.random.randn(200, 3),
@@ -109,22 +121,25 @@ st.write(c)
 ```
 
 ## Demo app
-The deployed Streamlit app should look something like the one shown in the below link: 
+
+The deployed Streamlit app should look something like the one shown in the below link:
 
 [![Streamlit App](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://share.streamlit.io/dataprofessor/st.write/)
 
 ## Next steps
 
-Now that you have created the Streamlit app locally, it's time to deploy it to [Streamlit Cloud](https://streamlit.io/cloud) as will be explained soon in an upcoming challenge. 
+Now that you have created the Streamlit app locally, it's time to deploy it to [Streamlit Cloud](https://streamlit.io/cloud) as will be explained soon in an upcoming challenge.
 
-Because this is the first week of your challenge, we provide the full code (as shown in the code box above) and solution (the demo app) right inside this webpage. 
+Because this is the first week of your challenge, we provide the full code (as shown in the code box above) and solution (the demo app) right inside this webpage.
 
 Moving forward in the next challenges, it is recommended that you first try implementing the Streamlit app yourself.
 
 Don't worry if you get stuck, you can always take a peek at the solution.
 
 ## Further reading
+
 In addition to [`st.write`](https://docs.streamlit.io/library/api-reference/write-magic/st.write), you can explore the other ways of displaying text:
+
 - [`st.markdown`](https://docs.streamlit.io/library/api-reference/text/st.markdown)
 - [`st.header`](https://docs.streamlit.io/library/api-reference/text/st.header)
 - [`st.subheader`](https://docs.streamlit.io/library/api-reference/text/st.subheader)


### PR DESCRIPTION
In addition to formatting Markdown, this PR substitutes instances of `function` and `method` with `command`.

- **Streamlit command** (not "function", "method", etc): any of our main API calls. Examples: `st.write`, `st.cache`, `st.line_chart()` , etc.
- We use the word command because (1) it's more "scripty", and (2) function/method have meanings that in the end depend on implementation details. Some commands are actually implemented as functions while others are methods, but the user shouldn't care.