### PR TITLE
Support query params for daily challenges

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -6,6 +6,9 @@ import urllib.request
 from PIL import Image
 import glob
 
+def update_params():
+    st.experimental_set_query_params(challenge=st.session_state.day)
+
 md_files = sorted([int(x.strip('Day').strip('.md')) for x in glob.glob1('content',"*.md") ])
 
 # Logo and Navigation
@@ -15,7 +18,13 @@ with col2:
 st.markdown('# 30 Days of Streamlit')
 
 days_list = [f'Day {x}' for x in md_files]
-selected_day = st.selectbox('Start the Challenge 👇', days_list)
+
+query_params = st.experimental_get_query_params()
+
+if query_params and query_params["challenge"][0] in days_list:
+    st.session_state.day = query_params["challenge"][0]
+
+selected_day = st.selectbox('Start the Challenge 👇', days_list, key="day", on_change=update_params)
 
 with st.expander("About the #30DaysOfStreamlit"):
     st.markdown('''


### PR DESCRIPTION
This PR adds support for query params so that we can share challenge specific links, for example:
- https://share.streamlit.io/snehankekre/30days/query-params-challenges?challenge=Day+2
- https://share.streamlit.io/snehankekre/30days/query-params-challenges?challenge=Day+8

Changing the selectbox value will update the URL, and accessing a specific day's URL will update the selectbox value. The idea is that participants will be able to share challenges for specific days. We can even use day-specific URLs in our daily social media posts. Here's an [app](https://share.streamlit.io/snehankekre/30days/query-params-challenges?challenge=Day+1) demonstrating this behavior.

https://user-images.githubusercontent.com/20672874/162945347-039e56e2-bafb-42d8-9825-e800e97dc19d.MOV


